### PR TITLE
added eye button to toggle password visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,6 +4,24 @@
   padding: 0;
   font-family: Arial, Helvetica, sans-serif;
 }
+.password-container {
+  position: relative;
+}
+
+.password-container input {
+  width: 100%;
+  padding-right: 30px; 
+}
+
+.toggle-password {
+  position: absolute;
+  top: 30%;
+  right: 10px;
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 16px;
+}
+
 input {
   outline: 0;
 }
@@ -11,6 +29,7 @@ input[type="submit"] {
   border: 0;
   cursor: pointer;
 }
+
 a {
   color: rgb(226, 74, 74);
   text-decoration: none;

--- a/login.html
+++ b/login.html
@@ -97,15 +97,22 @@
             <div class="heading-border"></div>
 
             <form action="" class="form">
-                <fieldset>
-                    <legend>Login</legend>
-                    <p class="label">Email</p>
-                    <input type="email" placeholder="Enter your email..." required>
-                    <p class="label">Password</p>
-                    <input type="password" placeholder="Enter your password..." required>
-                    <input type="submit" value="Login" class="btn-primary">
-                </fieldset>
-            </form>
+            <fieldset>
+                <legend>Login</legend>
+                <p class="label">Email</p>
+                <input type="email" placeholder="Enter your email..." required>
+
+               <p class="label">Password</p>
+                <div class="password-container">
+                <input type="password" id="password" placeholder="Enter your password..." required>
+                <span class="toggle-password" onclick="togglePassword()">👁️</span>
+            </div>
+
+
+                <input type="submit" value="Login" class="btn-primary">
+            </fieldset>
+        </form>
+
         </div>
     </section>
     <!-- Login Section End -->
@@ -207,5 +214,20 @@
     <script src="https://code.jquery.com/ui/1.13.0/jquery-ui.js"></script>
     <!-- Custom JS -->
     <script src="js/custom.js"></script>
+    <script>
+    function togglePassword() {
+        const passwordInput = document.getElementById("password");
+        const toggleIcon = document.querySelector(".toggle-password");
+
+        if (passwordInput.type === "password") {
+        passwordInput.type = "text";
+        toggleIcon.textContent = "🙈";
+        } else {
+        passwordInput.type = "password";
+        toggleIcon.textContent = "👁️";
+        }
+    }
+    </script>
+
 </body>
 </html>


### PR DESCRIPTION
This PR introduces a simple and user-friendly password visibility toggle feature to the login form. An eye icon (👁️) is added beside the password input field, allowing users to toggle between showing and hiding their password input.
 This improves the user experience during login by helping users verify their password input, reducing the likelihood of input errors.

Fixes #77 

<img width="1226" height="464" alt="image" src="https://github.com/user-attachments/assets/62764ce8-83c0-43b2-8215-e47c121185b0" />
